### PR TITLE
fix:Blue/Greenの設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # aws-ecs-development
 TerraformでECS環境(`Blue/Green Deploy`)を構築するサンプルです
+
 ## AWSリソースの更新方法
 - `CodeBuild`と`tfnotify`を使用して、`terraform plan/apply`の結果が自動的にGitHubに通知される仕組みを構築している
-- プルリクエストを作成して、tfnotifyから通知される`terraform plan`の結果に問題ないか確認
+- プルリクエストを作成して、`tfnotify`から通知される`terraform plan`の結果に問題ないか確認
 - mainブランチにmergeすると、自動的に`terraform apply`する
+
+## AWSリソースの削除方法
+~~~
+terraform destroy
+~~~

--- a/environments/alb.tf
+++ b/environments/alb.tf
@@ -5,7 +5,10 @@ resource "aws_lb" "my-app-alb" {
   internal           = false
   ip_address_type    = "ipv4"
   security_groups = [ aws_security_group.my-app-lb-sg.id ]
-  subnets = [ aws_subnet.my-workspace-subnet-app-public1-a.id, aws_subnet.my-workspace-subnet-app-public1-b.id ]
+  subnets = [ 
+    aws_subnet.my-workspace-subnet-app-public1-a.id, 
+    aws_subnet.my-workspace-subnet-app-public1-c.id
+  ]
 
   tags = {
     "Name" : "my-app-alb"

--- a/environments/ecs.tf
+++ b/environments/ecs.tf
@@ -1,15 +1,15 @@
 
-// クラスターの作成
+# クラスターの作成
 resource "aws_ecs_cluster" "my-app-cluster" {
   name = "my-app-cluster"
 }
 
-// タスク定義の作成
-// https://zenn.dev/hsaki/books/golang-grpc-starting/viewer/awshost
-// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition
-// https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/task-cpu-memory-error.html
-// https://gallery.ecr.aws/nginx/nginx
-// https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/task_definition_parameters.html
+# タスク定義の作成
+## https://zenn.dev/hsaki/books/golang-grpc-starting/viewer/awshost
+## https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition
+## https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/task-cpu-memory-error.html
+## https://gallery.ecr.aws/nginx/nginx
+## https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/task_definition_parameters.html
 resource "aws_ecs_task_definition" "my-app-frontend" {
   family                   = "my-app-frontend"
   requires_compatibilities = ["FARGATE"]
@@ -38,17 +38,17 @@ resource "aws_ecs_task_definition" "my-app-frontend" {
       }
     }
   ])
-  // OSとアーキテクチャの指定
+  # OSとアーキテクチャの指定
   runtime_platform {
     operating_system_family = "LINUX"
     cpu_architecture        = "X86_64"
   }
 
-  // NOTE: Nginxのイメージを使用するだけなので、タスク実行ロールのみ付与
+  # NOTE: Nginxのイメージを使用するだけなので、タスク実行ロールのみ付与
   execution_role_arn = aws_iam_role.my-app-task-execution-role.arn
 }
 
-// サービスの作成
+# サービスの作成
 resource "aws_ecs_service" "my-app-frontend-service" {
   name                = "my-app-frontend-service"
   cluster             = aws_ecs_cluster.my-app-cluster.arn
@@ -59,5 +59,22 @@ resource "aws_ecs_service" "my-app-frontend-service" {
   desired_count       = 1
   deployment_controller {
     type = "CODE_DEPLOY"
+  }
+  
+  network_configuration {
+    # パブリックIPの自動割り当てを有効化
+    assign_public_ip = true
+    security_groups = [
+      aws_security_group.my-app-frontend-sg.id
+    ]
+    subnets = [ 
+      aws_subnet.my-workspace-subnet-app-public1-a.id,
+      aws_subnet.my-workspace-subnet-app-public1-b.id
+    ]
+  }
+  load_balancer {
+    target_group_arn = aws_lb_target_group.my-app-frontend-tg-1.arn
+    container_name = "frontend"
+    container_port = 80
   }
 }

--- a/environments/ecs.tf
+++ b/environments/ecs.tf
@@ -69,7 +69,7 @@ resource "aws_ecs_service" "my-app-frontend-service" {
     ]
     subnets = [ 
       aws_subnet.my-workspace-subnet-app-public1-a.id,
-      aws_subnet.my-workspace-subnet-app-public1-b.id
+      aws_subnet.my-workspace-subnet-app-public1-c.id
     ]
   }
   load_balancer {

--- a/environments/iam.tf
+++ b/environments/iam.tf
@@ -36,7 +36,8 @@ data "aws_iam_policy_document" "my-app-ecs-codedeploy-assume-policy" {
   }
 }
 
+# IAMポリシー(AWSCodeDeployRoleForECS)をアタッチ
 resource "aws_iam_role_policy_attachment" "my-app-ecs-codedeploy-assume-policy" {
-  role       = aws_iam_role.my-app-ecs-codedeploy-role.arn
+  role       = aws_iam_role.my-app-ecs-codedeploy-role.name
   policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS"
 }

--- a/environments/network.tf
+++ b/environments/network.tf
@@ -30,12 +30,12 @@ resource "aws_subnet" "my-workspace-subnet-app-public1-a" {
 }
 
 // パブリックサブネットの作成
-resource "aws_subnet" "my-workspace-subnet-app-public1-b" {
+resource "aws_subnet" "my-workspace-subnet-app-public1-c" {
   vpc_id            = aws_vpc.my-workspace-vpc.id
   cidr_block        = var.aws_public1b_subnet_cider
-  availability_zone = "ap-northeast-1b"
+  availability_zone = "ap-northeast-1c"
   tags = {
-    Name = "my-workspace-subnet-app-public1-b"
+    Name = "my-workspace-subnet-app-public1-c"
   }
   map_public_ip_on_launch = true
 }

--- a/environments/security_group.tf
+++ b/environments/security_group.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "my-app-frontend-sg" {
   }
 }
 
-// インバウンドルール
+// インバウンドルール(ユーザー向け)
 resource "aws_vpc_security_group_ingress_rule" "my-app-frontend-sg-ingress" {
   security_group_id = aws_security_group.my-app-frontend-sg.id
   cidr_ipv4         = "0.0.0.0/0"
@@ -35,15 +35,6 @@ resource "aws_security_group" "my-app-lb-sg" {
     description = "allow all outbound traffic by default"
     cidr_blocks = ["0.0.0.0/0"]
   }
-}
-
-// インバウンドルール(ユーザー向け)
-resource "aws_vpc_security_group_ingress_rule" "my-app-lb-sg-ingress" {
-  security_group_id = aws_security_group.my-app-frontend-sg.id
-  cidr_ipv4         = "0.0.0.0/0"
-  from_port         = 80
-  ip_protocol       = "tcp"
-  to_port           = 80
 }
 
 // インバウンドルール(開発者向け)


### PR DESCRIPTION
# プルリクエスト概要
- Blue/Greenデプロイに対応するための変更
## 変更点
- ECSにセキュリティグループとサブネット、ALBの紐付け
- パブリックサブネットのAZを`ap-northeast-1c`に変更
- インバウンドルール（ユーザー向け）の重複削除
- （その他）CodeBuild用のIAMロールの権限を追加
## レビュー観点
- [x] リソースの命名規則に問題がないか
- [x] `terraform plan`の結果に問題ないか
